### PR TITLE
add heuristic for excluding auto-generated containers/identities

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,12 +3,16 @@ var backup = function () {
     var identities = containers.map((container) => {
       return { name: container.name, color: container.color, icon: container.icon, colorCode: container.colorCode }
     });
+    identities = filter(identities)
     browser.storage.sync.set({ identities: identities });
   });
 }
 
 var restore = function () {
   browser.storage.sync.get().then((data) => {
+    if(data.identities){
+      data.identities = filter(data.identities)
+    }
     data.identities.map((identity) => {
       browser.contextualIdentities.query({name: identity.name}).then((result) => {
         if(result.length === 0){
@@ -17,6 +21,28 @@ var restore = function () {
       })
     });
   })
+}
+
+var filter = function (identities) {
+  var identityGroups = {}
+  identities.map((identity) => {
+    var nameMatch = identity.name.match(/^([a-zA-Z-_]+)\d$/)
+    if(nameMatch){
+      var stem = nameMatch[1]
+      if(!(stem in identityGroups)){
+        identityGroups[stem] = []
+      }
+      identityGroups[stem].push(identity.name)
+    }
+  })
+  var filterList = Object.values(identityGroups).filter((group) => {
+    return group.length > 1
+  }).flat()
+  var filtered = identities.filter((identity, idx, identities) => {
+    return filterList.indexOf(identity.name) === -1
+  })
+  console.debug("Containers Sync Filter Report\n======\nIN: %o\nGROUPS:%o\nOUT: %o", identities, identityGroups, filtered)
+  return filtered
 }
 
 var handleInstall = function (details) {


### PR DESCRIPTION
Adds support for #7. 



The implementation is on the conservative side to insure that it
- works with any configuration of Temporary Containers (any prefix, any color, any symbol, even with randomization)
- works with different configurations of Temporary Containers on different machines - e.g. it does not use a fixed prefix
- it only triggers when it finds at least two containers matching ```^([a-zA-Z-_]+)\d$``` with the same stem (prefix)
- it filters both backup and restore => excludes single auto-generated identities


### What's left?
The pull request is shippable. A later version could add preferences (including UI) for manual configuration of exclusion criteria.